### PR TITLE
Fix delete() function

### DIFF
--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -569,6 +569,9 @@ public extension BoxingPersistentStruct {
         do {
             let object = try ctx.existingObjectWithID(oid)
             ctx.deleteObject(object)
+            //Commit changes to remove object from the uniquing tables
+            try ctx.save()
+            
         } catch let error {
             CVManagedStructError.StructDeleteError(message: "Could not locate object \(oid) in context \(context): \(error)")
         }


### PR DESCRIPTION
Automatically commit changes to the backing store after calling `object.delete()`. Because user can forget to call `save()` and the intent of this library is to abstract away `ManagedObjectContext` details. In the README tutorial save() also isn't called after  `aShop.delete(self.context)`.