### PR TITLE
Fix parsing values when valueMirror.children is empty

### DIFF
--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -596,7 +596,7 @@ private func internalToObject<T: BoxingStruct>(context: NSManagedObjectContext?,
                 case (.Optional?, let child?):
                     result.setValue(child.value as? AnyObject, forKey: label)
                     break
-                case (.Collection?, _?):
+                case (.Collection?, _):
                     var objects: [NSManagedObject] = []
                     for (_, value) in valueMirror.children {
                         if let boxedValue = value as? BoxingStruct {


### PR DESCRIPTION
Hey, I've found bug when relationship one-to-many does not contain any values it triggers "Could not decode value for field ...". And when I removed the question mark it was ok. 

But I think there should be some tests, so we can be sure that this is working properly.