### PR TITLE
Add better suppport for nested collections in persistent structs

### DIFF
--- a/CollectionTests.swift
+++ b/CollectionTests.swift
@@ -1,0 +1,152 @@
+//
+//  CollectionTests.swift
+//  CoreValue
+//
+//  Created by Roman Kříž on 21/02/16.
+//  Copyright © 2016 Benedikt Terhechte. All rights reserved.
+//
+
+import XCTest
+import CoreData
+
+
+struct StoredEmployee : CVManagedPersistentStruct {
+    static let EntityName = "Employee"
+    var objectID: NSManagedObjectID?
+
+    let name: String
+    let age: Int16
+    let position: String?
+    let department: String
+    let job: String
+
+    static func fromObject(o: NSManagedObject) throws -> StoredEmployee {
+        return try curry(self.init)
+            <^> o <|? "objectID"
+            <^> o <| "name"
+            <^> o <| "age"
+            <^> o <|? "position"
+            <^> o <| "department"
+            <^> o <| "job"
+    }
+}
+
+struct StoredCompany: CVManagedPersistentStruct {
+    static let EntityName = "Company"
+    var objectID: NSManagedObjectID?
+
+    var name: String
+    var employees: Array<StoredEmployee>
+
+    static func fromObject(o: NSManagedObject) throws -> StoredCompany {
+        return try curry(self.init)
+            <^> o <|? "objectID"
+            <^> o <| "name"
+            <^> o <|| "employees"
+    }
+
+    mutating func save(context: NSManagedObjectContext) throws {
+        try employees.saveAll(context)
+
+        try defaultSave(context)
+    }
+}
+
+
+
+
+class CoreValueCollectionsTests: XCTestCase {
+
+    var context: NSManagedObjectContext = {
+        return setUpInMemoryManagedObjectContext(CoreValueMacTests)!
+    }()
+
+    var company: StoredCompany = {
+        let employees = [
+            StoredEmployee(objectID: nil, name: "1", age: 10, position: nil, department: "a", job: "b"),
+            StoredEmployee(objectID: nil, name: "2", age: 20, position: nil, department: "d", job: "b"),
+            StoredEmployee(objectID: nil, name: "3", age: 30, position: nil, department: "g", job: "b"),
+            StoredEmployee(objectID: nil, name: "4", age: 40, position: nil, department: "i", job: "b")
+        ]
+
+        return StoredCompany(objectID: nil, name: "Company", employees: employees)
+    }()
+
+    func testSavingNestedCollectionSettingObjectID() {
+        var s1 = self.company
+
+        testTry {
+            try s1.save(self.context)
+        }
+
+        XCTAssertNotNil(s1.objectID)
+        XCTAssertNotNil(s1.employees[0].objectID)
+    }
+
+    func testSavingTwoTimes() {
+        var s1 = self.company
+
+        testTry {
+            try s1.save(self.context)
+        }
+
+        let beforeEmployeeID = s1.employees.first?.objectID
+
+        testTry {
+            try s1.save(self.context)
+        }
+
+        let afterEmployeeID = s1.employees.first?.objectID
+
+        XCTAssertNotNil(beforeEmployeeID)
+        XCTAssertEqual(beforeEmployeeID, afterEmployeeID)
+
+        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+        XCTAssertEqual(after.first?.employees.count, 4)
+    }
+
+    func testRemovingItemFromNestedCollection() {
+        var s1 = self.company
+
+        testTry {
+            try s1.save(self.context)
+        }
+
+        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+        XCTAssertEqual(before.first?.employees.count, 4)
+
+        s1.employees.removeFirst()
+
+        testTry {
+            try s1.save(self.context)
+        }
+
+        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+        XCTAssertEqual(after.first?.employees.count, 3)
+    }
+
+    func testRemovingAllItemsFromNestedCollection() {
+        var s1 = self.company
+
+        // save for the first time
+        testTry {
+            try s1.save(self.context)
+        }
+
+        // check the count of employees
+        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+        XCTAssertEqual(before.first?.employees.count, 4)
+
+        // remove all employees from original struct
+        s1.employees.removeAll()
+
+        // save the changes
+        testTry {
+            try s1.save(self.context)
+        }
+
+        // check for resulting
+        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+        XCTAssertEqual(after.first?.employees.count, 0)
+    }
+}

--- a/CoreValue.xcodeproj/project.pbxproj
+++ b/CoreValue.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F13B6DF1C79EF3D0099947C /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13B6DD1C79EF000099947C /* CollectionTests.swift */; };
+		2F13B6E01C79EF3E0099947C /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13B6DD1C79EF000099947C /* CollectionTests.swift */; };
 		4D2680261B4C5091001F8D35 /* CoreValueTests.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */; };
 		4D391F251B5404C300C66C90 /* CoreValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D59128F1B498AFA0022506E /* CoreValueTests.swift */; };
 		4D391F261B5404CE00C66C90 /* CoreValueTests.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */; };
@@ -45,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2F13B6DD1C79EF000099947C /* CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; name = CoreValueTests.xcdatamodel; path = CoreValueMacTests/CoreValueTests.xcdatamodel; sourceTree = "<group>"; };
 		4D391F271B5404ED00C66C90 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreData.framework; sourceTree = DEVELOPER_DIR; };
 		4D5912581B4989FB0022506E /* CoreValue.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CoreValue.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -113,6 +116,7 @@
 			children = (
 				4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */,
 				4D59128F1B498AFA0022506E /* CoreValueTests.swift */,
+				2F13B6DD1C79EF000099947C /* CollectionTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -372,6 +376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D391F261B5404CE00C66C90 /* CoreValueTests.xcdatamodel in Sources */,
+				2F13B6DF1C79EF3D0099947C /* CollectionTests.swift in Sources */,
 				4D391F251B5404C300C66C90 /* CoreValueTests.swift in Sources */,
 				4D5912741B498A170022506E /* CoreValue.swift in Sources */,
 				4D6AEB9A1B4DEAE100DDD5E1 /* curry.swift in Sources */,
@@ -392,6 +397,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D5912991B498B000022506E /* CoreValue.swift in Sources */,
+				2F13B6E01C79EF3E0099947C /* CollectionTests.swift in Sources */,
 				4D2680261B4C5091001F8D35 /* CoreValueTests.xcdatamodel in Sources */,
 				4D5912901B498AFA0022506E /* CoreValueTests.swift in Sources */,
 				4D6AEB9C1B4DEAE100DDD5E1 /* curry.swift in Sources */,

--- a/CoreValueMacTests/CoreValueTests.swift
+++ b/CoreValueMacTests/CoreValueTests.swift
@@ -92,7 +92,7 @@ struct StoredShop: CVManagedPersistentStruct {
 }
 
 /// Attempt f, fail test if it throws
-private func testTry(@noescape f: () throws -> ()) {
+func testTry(@noescape f: () throws -> ()) {
     do {
         try f()
     } catch let error as NSError {


### PR DESCRIPTION
Hey, I've found that nested collections are not supported the same way I expected so I've made some changes to make it little bit better.

Main problem was that when you save persistent struct twice it saves inserts objects in nested collection twice. So it ends up by having collection with twice more values than you expected :D  
