### PR TITLE
Added RawRepresantable conformance to Boxing and Unboxing

### DIFF
--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -462,6 +462,23 @@ extension NSDecimalNumber: Unboxing, Boxing {
     }
 }
 
+public extension Boxing where Self: RawRepresentable, Self.RawValue :Boxing {
+    func box(object: NSManagedObject, withKey: String) throws {
+        return try self.rawValue.box(object, withKey: withKey)
+    }
+}
+
+public extension Unboxing where Self.StructureType == Self, Self: RawRepresentable, Self.RawValue :Unboxing {
+    static func unbox(value: AnyObject) throws -> StructureType {
+        let rawValue = try Self.RawValue.unbox(value)
+        if let r = rawValue as? Self.RawValue, enumValue = self.init(rawValue: r) {
+            return enumValue
+        }
+        
+        throw NSError(unboxErrorMessage: "\(self.dynamicType)")
+    }
+}
+
 // MARK: -
 // MARK: Reflection Support
 

--- a/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
+++ b/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="8118.20" systemVersion="14D136" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15B42" minimumToolsVersion="Automatic">
+    <entity name="Car" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <entity name="Company" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="employees" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Employee" inverseName="company" inverseEntity="Employee" syncable="YES"/>
@@ -31,5 +35,6 @@
         <element name="Employee" positionX="-63" positionY="-18" width="128" height="150"/>
         <element name="Other" positionX="-54" positionY="36" width="128" height="30"/>
         <element name="Shop" positionX="-54" positionY="27" width="128" height="75"/>
+        <element name="Car" positionX="-45" positionY="54" width="128" height="75"/>
     </elements>
 </model>


### PR DESCRIPTION
Similarily as described here:

https://github.com/thoughtbot/Argo/blob/master/Documentation/Decode-Enums.md

Now it is possible to do for example:

```
enum CarType:String{
    case Pickup = "pickup"
    case Sedan = "sedan"
    case Hatchback = "hatchback"
}

extension CarType: Boxing,Unboxing {}
```

And CoreValue will save the enum raw value to the core data. 

Note that the rawValue type of enum have to conform to Boxing and Unboxing
