### PR TITLE
Addition of CVManagedUniqueStruct

### DIFF
--- a/CoreValue.xcodeproj/project.pbxproj
+++ b/CoreValue.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2F13B6DF1C79EF3D0099947C /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13B6DD1C79EF000099947C /* CollectionTests.swift */; };
 		2F13B6E01C79EF3E0099947C /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13B6DD1C79EF000099947C /* CollectionTests.swift */; };
 		4D2680261B4C5091001F8D35 /* CoreValueTests.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */; };
 		4D391F251B5404C300C66C90 /* CoreValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D59128F1B498AFA0022506E /* CoreValueTests.swift */; };
@@ -27,6 +26,7 @@
 		4D6AEB9A1B4DEAE100DDD5E1 /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6AEB981B4DEAE100DDD5E1 /* curry.swift */; };
 		4D6AEB9B1B4DEAE100DDD5E1 /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6AEB981B4DEAE100DDD5E1 /* curry.swift */; };
 		4D6AEB9C1B4DEAE100DDD5E1 /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6AEB981B4DEAE100DDD5E1 /* curry.swift */; };
+		AC90177A1D3AE28100F33670 /* UniqueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC9017791D3AE28100F33670 /* UniqueTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +64,7 @@
 		4D59128F1B498AFA0022506E /* CoreValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = CoreValueTests.swift; path = CoreValueMacTests/CoreValueTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		4D5912911B498AFA0022506E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4D6AEB981B4DEAE100DDD5E1 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = curry.swift; sourceTree = "<group>"; };
+		AC9017791D3AE28100F33670 /* UniqueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UniqueTests.swift; path = CoreValueMacTests/UniqueTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +118,7 @@
 				4D2680251B4C5091001F8D35 /* CoreValueTests.xcdatamodel */,
 				4D59128F1B498AFA0022506E /* CoreValueTests.swift */,
 				2F13B6DD1C79EF000099947C /* CollectionTests.swift */,
+				AC9017791D3AE28100F33670 /* UniqueTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -375,8 +377,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AC90177A1D3AE28100F33670 /* UniqueTests.swift in Sources */,
 				4D391F261B5404CE00C66C90 /* CoreValueTests.xcdatamodel in Sources */,
-				2F13B6DF1C79EF3D0099947C /* CollectionTests.swift in Sources */,
 				4D391F251B5404C300C66C90 /* CoreValueTests.swift in Sources */,
 				4D5912741B498A170022506E /* CoreValue.swift in Sources */,
 				4D6AEB9A1B4DEAE100DDD5E1 /* curry.swift in Sources */,

--- a/CoreValue.xcodeproj/project.pbxproj
+++ b/CoreValue.xcodeproj/project.pbxproj
@@ -153,8 +153,8 @@
 		4D59125A1B4989FB0022506E /* CoreValue */ = {
 			isa = PBXGroup;
 			children = (
-				4D5912721B498A170022506E /* CoreValue.swift */,
 				4D6AEB981B4DEAE100DDD5E1 /* curry.swift */,
+				4D5912721B498A170022506E /* CoreValue.swift */,
 				4D391F291B5404FE00C66C90 /* Frameworks */,
 			);
 			path = CoreValue;

--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -652,6 +652,7 @@ public extension BoxingUniqueStruct {
      */
     func defaultSave(context: NSManagedObjectContext) throws {
         try self.toObject(context)
+        try context.save()
     }
     
     public func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {

--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -642,7 +642,6 @@ private func internalToObject<T: BoxingStruct>(context: NSManagedObjectContext?,
                     result.setValue(nil, forKey: label)
                     // Optional with Value
                 case (.Optional?, let child?):
-                    result.setValue(child.value as? AnyObject, forKey: label)
                     let optionalMirror: Mirror = Mirror(reflecting: child.value)
                     
                     switch (optionalMirror.displayStyle, optionalMirror.children.first) {
@@ -679,9 +678,14 @@ private func internalCollectionToSet(context: NSManagedObjectContext?, result: N
         }
     }
     
-    if objects.count > 0 {
-        let mutableValue = result.mutableOrderedSetValueForKey(label)
-        mutableValue.addObjectsFromArray(objects)
+    let orderedSet = NSOrderedSet(array: objects)
+    
+    let mutableValue = result.mutableOrderedSetValueForKey(label)
+    if objects.count == 0 {
+        mutableValue.removeAllObjects()
+    } else {
+        mutableValue.intersectOrderedSet(orderedSet) // removes objects that are not in new array
+        mutableValue.unionOrderedSet(orderedSet) // adds new objects
     }
 }
 

--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -142,16 +142,16 @@ extension BoxingStruct {
 }
 
 /**
-   Add support for persistence, i.e. entities that know they were fetched from a context
-   and can appropriately update themselves in the context, or be deleted, etc.
-   Still a basic implementation.
-
-   Caveats:
-   - If type T: BoxingPersistentStruct has a property Tx: BoxingStruct, then saving/boxing
-     T will create new instances of Tx. So, as a requirement that is with the current swift compiler
-     impossible to define in types, any property on BoxingPersistentStruct also has to be of
-     type BoxingPersistentStruct
-*/
+ Add support for persistence, i.e. entities that know they were fetched from a context
+ and can appropriately update themselves in the context, or be deleted, etc.
+ Still a basic implementation.
+ 
+ Caveats:
+ - If type T: BoxingPersistentStruct has a property Tx: BoxingStruct, then saving/boxing
+ T will create new instances of Tx. So, as a requirement that is with the current swift compiler
+ impossible to define in types, any property on BoxingPersistentStruct also has to be of
+ type BoxingPersistentStruct
+ */
 
 public protocol BoxingPersistentStruct : BoxingStruct {
     /** If this value type is based on an existing object, this is the object id, so we can
@@ -181,6 +181,65 @@ public protocol BoxingPersistentStruct : BoxingStruct {
         Throws CVManagedStructErorr if saving fails */
     mutating func save(context: NSManagedObjectContext) throws
 }
+
+/**
+ Unique identifier in CoreData. Conform your identifier type to the protocol to use it in Boxing Unique struct
+ */
+public protocol IdentifierType {
+    func predicate(identifierName: String) -> NSPredicate
+}
+
+extension String: IdentifierType {
+    public func predicate(name: String) -> NSPredicate {
+        return NSPredicate(format: "\(name) = %@", self)
+    }
+}
+
+extension Int: IdentifierType {
+    public func predicate(name: String) -> NSPredicate {
+        return NSPredicate(format: "\(name) = %i", self)
+    }
+}
+
+extension Int16: IdentifierType {
+    public func predicate(name: String) -> NSPredicate {
+        return NSPredicate(format: "\(name) = %i", self)
+    }
+}
+
+extension Int32: IdentifierType {
+    public func predicate(name: String) -> NSPredicate {
+        return NSPredicate(format: "\(name) = %i", self)
+    }
+}
+
+/**
+ Adds support for persistence using the struct unique identifier, i.e. any entity with the same identifier will be fetched, updated or deleted accordingly.
+ */
+
+public protocol BoxingUniqueStruct : BoxingStruct {
+    /** Name of the Identifier in the CoreData (e.g: 'id')
+     */
+    static var IdentifierName: String {get}
+    
+    /** Value of the Identifier for the current struct (e.g: 'self.id')
+     */
+    func IdentifierValue() -> IdentifierType
+    
+    /** Delete an object from the managedObjectStore.
+     
+     Throws an instance of CVManagedStructError in case the object cannot be found
+     in the managedObjectStore or if deletion fails due to an underlying core data
+     error.
+     */
+    func delete(context: NSManagedObjectContext?) throws
+    
+    /** Save an object to the managedObjectStore or update the current instance in the
+     managedObjectStore with the current Value Type properties.
+     Throws CVManagedStructErorr if saving fails */
+    func save(context: NSManagedObjectContext) throws
+}
+
 
 public protocol UnboxingStruct : Unboxing {
     /** 
@@ -231,6 +290,13 @@ public protocol CVManagedStruct : _CVManagedStruct {
 public typealias _CVManagedPersistentStruct = protocol<BoxingPersistentStruct, UnboxingStruct>
 
 public protocol CVManagedPersistentStruct : _CVManagedPersistentStruct {
+    associatedtype StructureType = Self
+}
+
+
+public typealias _CVManagedUniqueStruct = protocol<BoxingUniqueStruct, UnboxingStruct>
+
+public protocol CVManagedUniqueStruct : _CVManagedUniqueStruct {
     associatedtype StructureType = Self
 }
 
@@ -531,6 +597,135 @@ private extension BoxingPersistentStruct {
         } else {
             return virginObjectForEntity(self.dynamicType.EntityName, context: context)
         }
+    }
+}
+
+private extension BoxingUniqueStruct {
+    
+    
+    
+   
+}
+
+public extension BoxingUniqueStruct {
+    
+    
+    func managedObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
+        if let ctx = context {
+            let predicate = try self.identifierPredicate()
+            
+            var managedObject: NSManagedObject
+            
+            let fetchRequest = NSFetchRequest(entityName: self.dynamicType.EntityName)
+            fetchRequest.predicate = predicate
+            
+            let fetchResults = try ctx.executeFetchRequest(fetchRequest)
+            if let fetchedObject = fetchResults.first as? NSManagedObject {
+                managedObject = fetchedObject
+            } else {
+                managedObject = virginObjectForEntity(self.dynamicType.EntityName, context: context)
+            }
+            
+            return managedObject
+            
+        } else {
+            return virginObjectForEntity(self.dynamicType.EntityName, context: context)
+        }
+    }
+    
+    func identifierPredicate() throws -> NSPredicate {
+        let identifierName = self.dynamicType.IdentifierName
+        let identifierValue = self.IdentifierValue()
+        return identifierValue.predicate(identifierName)
+    }
+    
+    //TODO: Should check if object exists - This will create and delete object
+    func delete(context: NSManagedObjectContext?) throws {
+        guard let ctx = context else { return }
+        
+        do {
+            let object = try managedObject(context)
+            ctx.deleteObject(object)
+            //Commit changes to remove object from the uniquing tables
+            try ctx.save()
+            
+        } catch let error {
+            CVManagedStructError.StructDeleteError(message: "Could not locate object in context \(context): \(error)")
+        }
+    }
+    
+    /**
+     Default implementation of save function since Swift Structs can't have inheritance.
+     */
+    func defaultSave(context: NSManagedObjectContext) throws {
+        try self.toObject(context)
+    }
+    
+    public func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
+        let result = try self.managedObject(context)
+        return try internalToObject(context, result: result, entity: self)
+    }
+    
+    /**
+     Point to override when saving nested collection, call .defaultSave method to perform original saving.
+     
+     Example:
+     mutating func save(context: NSManagedObjectContext) throws {
+     try self.someArray.saveAll(context)
+     try self.defaultSave(context)
+     }
+     */
+    func save(context: NSManagedObjectContext) throws {
+        try self.defaultSave(context)
+    }
+}
+
+public extension Array where Element: BoxingUniqueStruct {
+    /**
+     Converts array to objects using one fetch request
+     */
+    func toObjects(context: NSManagedObjectContext) throws -> [NSManagedObject] {
+        var predicates: [NSPredicate] = []
+        var objects: [NSManagedObject] = []
+        
+        for (idx, _) in enumerate() {
+            predicates.append(try self[idx].identifierPredicate())
+        }
+        
+        let predicate = NSCompoundPredicate(orPredicateWithSubpredicates: predicates)
+        
+        let fetchRequest = NSFetchRequest(entityName: Element.EntityName)
+        fetchRequest.predicate = predicate
+        
+        let fetchResults = try context.executeFetchRequest(fetchRequest)
+        
+        for (idx, _) in enumerate() {
+            let object = self[idx]
+            
+            var managedObject: NSManagedObject
+            
+            let singlePredicate = try object.identifierPredicate()
+            
+            //let resultsWithIdentifier = fetchResults.filter { object.IdentifierValue() as! String == $0.valueForKey(Element.IdentifierName) as! String }
+            
+            let resultsWithIdentifier = fetchResults.filter { singlePredicate.evaluateWithObject($0) }
+            
+            if let fetchedObject = resultsWithIdentifier.first as? NSManagedObject {
+                managedObject = fetchedObject
+            }else {
+                managedObject = virginObjectForEntity(Element.EntityName, context: context)
+            }
+            
+            managedObject = try internalToObject(context, result: managedObject, entity: object)
+            objects.append(managedObject)
+        }
+        
+        return objects
+    }
+    
+    func saveAll(context: NSManagedObjectContext) throws {
+        try self.toObjects(context)
+        //try context.save()
     }
 }
 

--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -717,6 +717,7 @@ public extension Array where Element: BoxingUniqueStruct {
     
     func saveAll(context: NSManagedObjectContext) throws {
         try self.toObjects(context)
+        try context.save()
     }
 }
 

--- a/CoreValue/CoreValue.swift
+++ b/CoreValue/CoreValue.swift
@@ -600,13 +600,6 @@ private extension BoxingPersistentStruct {
     }
 }
 
-private extension BoxingUniqueStruct {
-    
-    
-    
-   
-}
-
 public extension BoxingUniqueStruct {
     
     
@@ -706,8 +699,6 @@ public extension Array where Element: BoxingUniqueStruct {
             
             let singlePredicate = try object.identifierPredicate()
             
-            //let resultsWithIdentifier = fetchResults.filter { object.IdentifierValue() as! String == $0.valueForKey(Element.IdentifierName) as! String }
-            
             let resultsWithIdentifier = fetchResults.filter { singlePredicate.evaluateWithObject($0) }
             
             if let fetchedObject = resultsWithIdentifier.first as? NSManagedObject {
@@ -725,7 +716,6 @@ public extension Array where Element: BoxingUniqueStruct {
     
     func saveAll(context: NSManagedObjectContext) throws {
         try self.toObjects(context)
-        //try context.save()
     }
 }
 

--- a/CoreValueMacTests/CoreValueTests.swift
+++ b/CoreValueMacTests/CoreValueTests.swift
@@ -34,11 +34,26 @@ struct Shop: CVManagedStruct {
     
     var name: String
     var owner: Employee
+    var products: Array<Product>?
     
     static func fromObject(o: NSManagedObject) throws -> Shop {
         return try curry(self.init)
             <^> o <| "name"
             <^> o <| "owner"
+            <^> o <|| "products"
+    }
+}
+
+struct Product: CVManagedStruct {
+    static let EntityName = "Product"
+    
+    var name: String
+    var color: String
+    
+    static func fromObject(o: NSManagedObject) throws -> Product {
+        return try curry(self.init)
+            <^> o <| "name"
+            <^> o <| "color"
     }
 }
 
@@ -161,7 +176,7 @@ class CoreValueMacTests: XCTestCase {
     var nsEmployee2: NSManagedObject!
     
     let shop = {
-        return Shop(name: "Carl's Household Items", owner: Employee(name: "Carl", age: 66, position: nil, department: "Register", job: "Owner"))
+        return Shop(name: "Carl's Household Items", owner: Employee(name: "Carl", age: 66, position: nil, department: "Register", job: "Owner"), products: nil)
     }()
     
     var nsShop: NSManagedObject!
@@ -419,6 +434,29 @@ class CoreValueMacTests: XCTestCase {
             
         } catch let e {
             XCTAssert(false, "\(e)")
+        }
+    }
+    
+    func testOptionalCollectionToCoreData() {
+        // create two shops
+        let s1 = Shop(name: "shop_with_products1", owner: Employee(name: "a", age: 4, position: nil, department: "", job: ""), products: [Product(name: "Pancake", color:"golden")])
+        do {
+            try s1.toObject(self.context)
+        } catch let e {
+            XCTAssert(false, "\(e)")
+        }
+        
+        let s2 = Shop(name: "shop_with_products2", owner: Employee(name: "a", age: 4, position: nil, department: "", job: ""), products: [Product(name: "Unicorn", color: "sparkling")])
+        testTry {
+            try s2.toObject(self.context)
+        }
+        
+        // And query the count
+        testTry {
+            let predicate = NSPredicate(format: "self.name=='shop_with_products1'", argumentArray: [])
+            let results: [Shop] = try Shop.query(self.context, predicate: predicate)
+            XCTAssert(results.count == 1, "Wrong amount of objects, update did insert: \(results.count)")
+            XCTAssert(results.first?.products?.count == 1, "Wrong amount of products, actual amount: \(results.first?.products?.count ?? 0)")
         }
     }
 }

--- a/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
+++ b/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15B42" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15B42" minimumToolsVersion="Automatic">
     <entity name="Car" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
@@ -26,15 +26,22 @@
         <attribute name="float" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
         <attribute name="transformable" optional="YES" attributeType="Transformable" syncable="YES"/>
     </entity>
+    <entity name="Product" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="shop" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Shop" inverseName="products" inverseEntity="Shop" syncable="YES"/>
+    </entity>
     <entity name="Shop" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Employee" inverseName="shop" inverseEntity="Employee" syncable="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Product" inverseName="shop" inverseEntity="Product" syncable="YES"/>
     </entity>
     <elements>
+        <element name="Car" positionX="-45" positionY="54" width="128" height="75"/>
         <element name="Company" positionX="-54" positionY="36" width="128" height="75"/>
         <element name="Employee" positionX="-63" positionY="-18" width="128" height="150"/>
         <element name="Other" positionX="-54" positionY="36" width="128" height="30"/>
-        <element name="Shop" positionX="-54" positionY="27" width="128" height="75"/>
-        <element name="Car" positionX="-45" positionY="54" width="128" height="75"/>
+        <element name="Shop" positionX="-54" positionY="27" width="128" height="90"/>
+        <element name="Product" positionX="-54" positionY="45" width="128" height="90"/>
     </elements>
 </model>

--- a/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
+++ b/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
@@ -1,8 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15B42" minimumToolsVersion="Automatic">
+    <entity name="Article" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="articles" inverseEntity="Author" syncable="YES"/>
+        <relationship name="category" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Category" inverseName="articles" inverseEntity="Category" syncable="YES"/>
+    </entity>
+    <entity name="Author" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="articles" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Article" inverseName="author" inverseEntity="Article" syncable="YES"/>
+    </entity>
     <entity name="Car" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Category" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="articles" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Article" inverseName="category" inverseEntity="Article" syncable="YES"/>
     </entity>
     <entity name="Company" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -45,5 +62,8 @@
         <element name="Other" positionX="-54" positionY="36" width="128" height="30"/>
         <element name="Shop" positionX="-54" positionY="27" width="128" height="105"/>
         <element name="Product" positionX="-45" positionY="63" width="128" height="90"/>
+        <element name="Article" positionX="-36" positionY="72" width="128" height="105"/>
+        <element name="Author" positionX="-27" positionY="81" width="128" height="90"/>
+        <element name="Category" positionX="-9" positionY="99" width="128" height="105"/>
     </elements>
 </model>

--- a/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
+++ b/CoreValueMacTests/CoreValueTests.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15B42" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15B42" minimumToolsVersion="Automatic">
     <entity name="Car" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
@@ -27,16 +27,23 @@
         <attribute name="float" optional="YES" attributeType="Float" defaultValueString="0.0" syncable="YES"/>
         <attribute name="transformable" optional="YES" attributeType="Transformable" syncable="YES"/>
     </entity>
+    <entity name="Product" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="shop" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Shop" inverseName="products" inverseEntity="Shop" syncable="YES"/>
+    </entity>
     <entity name="Shop" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="employees" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Employee" inverseName="work" inverseEntity="Employee" syncable="YES"/>
         <relationship name="owner" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="Employee" inverseName="shop" inverseEntity="Employee" syncable="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Product" inverseName="shop" inverseEntity="Product" syncable="YES"/>
     </entity>
     <elements>
         <element name="Car" positionX="-45" positionY="54" width="128" height="75"/>
         <element name="Company" positionX="-54" positionY="36" width="128" height="75"/>
         <element name="Employee" positionX="-63" positionY="-18" width="128" height="165"/>
         <element name="Other" positionX="-54" positionY="36" width="128" height="30"/>
-        <element name="Shop" positionX="-54" positionY="27" width="128" height="90"/>
+        <element name="Shop" positionX="-54" positionY="27" width="128" height="105"/>
+        <element name="Product" positionX="-45" positionY="63" width="128" height="90"/>
     </elements>
 </model>

--- a/CoreValueMacTests/UniqueTests.swift
+++ b/CoreValueMacTests/UniqueTests.swift
@@ -27,12 +27,6 @@ struct Author : CVManagedUniqueStruct {
             <^> o <| "id"
             <^> o <| "name"
     }
-    
-    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
-    //        return try self.managedObject(context)
-    //            |> ("id", self.id)
-    //            |> ("name", self.name)
-    //    }
 }
 
 struct Article: CVManagedUniqueStruct {
@@ -53,13 +47,6 @@ struct Article: CVManagedUniqueStruct {
             <^> o <| "text"
             <^> o <|? "author"
     }
-    
-    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
-    //        return try self.managedObject(context)
-    //                |> ("id", self.id)
-    //                |> ("text", self.text)
-    //                ?|> ("author", self.author)
-    //    }
 }
 
 struct Category: CVManagedUniqueStruct {
@@ -97,14 +84,6 @@ struct Category: CVManagedUniqueStruct {
             <^> o <| "label"
             <^> o <|| "articles"
     }
-    
-    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
-    //        return try self.managedObject(context)
-    //            |> ("id", self.id)
-    //            |> ("type", self.type)
-    //            |> ("label", self.label)
-    //            ||> ("articles", self.articles)
-    //    }
 }
 
 

--- a/CoreValueMacTests/UniqueTests.swift
+++ b/CoreValueMacTests/UniqueTests.swift
@@ -1,0 +1,315 @@
+//
+//  UniqueTests.swift
+//  CoreValue
+//
+//  Created by Tomas Kohout on 7/16/16.
+//  Copyright © 2016 Benedikt Terhechte. All rights reserved.
+//
+
+import XCTest
+
+import CoreData
+
+
+struct Author : CVManagedUniqueStruct {
+    
+    static let EntityName = "Author"
+    
+    static var IdentifierName: String = "id"
+    
+    func IdentifierValue() -> IdentifierType { return self.id }
+    
+    let id: String
+    let name: String
+    
+    static func fromObject(o: NSManagedObject) throws -> Author {
+        return try curry(self.init)
+            <^> o <| "id"
+            <^> o <| "name"
+    }
+}
+
+struct Article: CVManagedUniqueStruct {
+    static let EntityName = "Article"
+    
+    static var IdentifierName: String = "id"
+    
+    func IdentifierValue() -> IdentifierType { return self.id }
+    
+    var id: Int16
+    var text: String
+    var author: Author?
+
+    
+    static func fromObject(o: NSManagedObject) throws -> Article {
+        return try curry(self.init)
+            <^> o <| "id"
+            <^> o <| "text"
+            <^> o <|? "author"
+    }
+}
+
+struct Category: CVManagedUniqueStruct {
+    static let EntityName = "Category"
+    
+    static var IdentifierName: String = "id"
+    
+    func IdentifierValue() -> IdentifierType { return self.id }
+    
+    //Create hash value for combined identifier
+    static func identifier(type type: String, label: String) -> String{
+        return "\(type)-\(label)"
+    }
+    
+    var id: String = ""
+    
+    var type: String {
+        didSet {
+            id = Category.identifier(type: type, label: label)
+        }
+    }
+    var label: String {
+        didSet {
+            id = Category.identifier(type: type, label: label)
+        }
+    }
+    
+    var articles: Array<Article>
+    
+    
+    static func fromObject(o: NSManagedObject) throws -> Category {
+        return try curry(self.init)
+            <^> o <| "id"
+            <^> o <| "type"
+            <^> o <| "label"
+            <^> o <|| "articles"
+    }
+}
+
+
+class UniqueTests: XCTestCase {
+    
+    var context: NSManagedObjectContext = {
+        return setUpInMemoryManagedObjectContext(CoreValueMacTests)!
+    }()
+    
+    
+    
+    
+    var category: Category = {
+        var author1 = Author(id: "e1x45", name: "Hemingway")
+        var author2 = Author(id: "hbx31", name: "Capek")
+        
+        let articles = [
+            Article(id: 1, text: "original_text_1", author: author1),
+            Article(id: 2, text: "original_text_2", author: author2),
+            Article(id: 3, text: "original_text_3", author: author1)
+        ]
+        
+        return Category(id: Category.identifier(type: "sports", label: "football"), type: "sports", label: "football", articles: articles)
+    }()
+    
+    var category_update: [Category] = {
+        var author1 = Author(id: "e1x45", name: "Hemingway")
+        var author2 = Author(id: "hbx31", name: "Kafka")
+        
+        let articles = [
+            Article(id: 1, text: "updated_text_1", author: author1),
+            Article(id: 2, text: "updated_text_2", author: author2),
+            Article(id: 3, text: "updated_text_3",  author: author1)
+        ]
+        
+        return [
+            Category(id: Category.identifier(type: "sports", label: "football"), type: "sports", label: "football", articles: [articles[0], articles[2]]),
+            Category(id: Category.identifier(type: "sports", label: "hockey"), type: "sports", label: "hockey", articles: [articles[1], articles[2]])
+        ]
+    }()
+    
+    
+    var manyCategories: [Category] = {
+        var box: [Article] = []
+        for c in 0..<25 {
+            box.append(Article(id: Int16(c), text: "text_\(c)", author: Author(id: "dfaw87", name: "Dostojevsky")))
+        }
+        var companyBox: [Category] = []
+        for c in 0..<50 {
+            companyBox.append(Category(id: "sports-basketball", type: "sports", label: "basketball", articles: box))
+        }
+        return companyBox
+    }()
+    
+    
+   
+    func testUniqueSavingTwoTimes() {
+        let s1 = self.category
+        
+        testTry {
+            try s1.save(self.context)
+        }
+        
+        testTry {
+            try s1.save(self.context)
+        }
+        
+        let after: [Category] = try! Category.query(self.context, predicate: nil)
+        XCTAssertEqual(after.count, 1)
+        XCTAssertEqual(after.first?.articles.count, 3)
+    }
+    
+    func testUpdatesCategory() {
+        var s1 = self.category
+        
+        testTry {
+            try s1.save(self.context)
+        }
+        
+        let after: [Category] = try! Category.query(self.context, predicate: NSPredicate(format: "label = %@", "football"))
+        XCTAssertEqual(after.count, 1)
+        
+        //Update identifier
+        s1.label = "curling"
+        
+        testTry {
+            try s1.save(self.context)
+        }
+        
+        let curling: [Category] = try! Category.query(self.context, predicate: NSPredicate(format: "label = %@", "curling"))
+        XCTAssertEqual(curling.count, 1)
+        
+        //Football stays the same (doesn't get deleted, this is desired behaviour)
+        let football: [Category] = try! Category.query(self.context, predicate: NSPredicate(format: "label = %@", "football"))
+        XCTAssertEqual(football.count, 1)
+    }
+    
+    
+    func testUpdatesBasedOnId() {
+        let s1 = self.category
+        
+        testTry {
+            try s1.save(self.context)
+        }
+        
+        let after: [Category] = try! Category.query(self.context, predicate: nil)
+        XCTAssertEqual(after.count, 1)
+        XCTAssertEqual(after.first?.articles.count, 3)
+        
+        let s2 = self.category_update
+        testTry {
+            try s2.saveAll(self.context)
+        }
+        
+        let after2: [Category] = try! Category.query(self.context, predicate: nil)
+        XCTAssertEqual(after2.count, 2)
+        
+        let category1 = after2.filter { $0.label == "football" && $0.type == "sports" }.first
+        
+        XCTAssertEqual(category1?.articles.count, 2)
+        XCTAssertEqual(category1?.articles[0].id, 1)
+        XCTAssertEqual(category1?.articles[1].id, 3)
+        
+        
+        
+        let category2 = after2.filter { $0.label == "hockey" && $0.type == "sports" }.first
+        
+        XCTAssertEqual(category2?.articles.count, 2)
+        XCTAssertEqual(category2?.articles[0].id, 2)
+        XCTAssertEqual(category2?.articles[1].id, 3)
+        XCTAssertEqual(category2?.articles[0].author?.name, "Kafka")
+    }
+    
+    func testSaveWithInconsistentData() {
+        
+        var category = self.category
+        
+        //Add another article to the category that has same id but different text
+        let conflictedId = category.articles[0].id
+        let conflictedArticle = Article( id: conflictedId, text: "conflicted_text", author: category.articles[0].author)
+        category.articles.append(conflictedArticle)
+
+        testTry {
+            try category.save(self.context)
+        }
+        
+        let after:[Category] = try! Category.query(self.context, predicate: NSPredicate(format: "id = %@", category.id))
+        
+        XCTAssertEqual(after.count, 1)
+        XCTAssertEqual(category.articles[0].text, "original_text_1")
+        
+        //The last one in array should be saved
+        XCTAssertEqual(after.first?.articles[0].text, "conflicted_text")
+    }
+    
+    
+    func testToObjectPerformance() {
+        testTry {
+            self.measureBlock {
+                testTry {
+                    let results: [NSManagedObject] = try self.manyCategories.map { category in
+                        let managedCompany = try category.toObject(self.context)
+                        XCTAssert(managedCompany.valueForKey("id") as? String == category.id)
+                        return managedCompany
+                    }
+                    XCTAssert(results.count == self.manyCategories.count, "Unboxed Companies have to be the same amount of entities")
+                }
+            }
+        }
+    }
+    
+    func testToObjectsPerformance() {
+        testTry {
+            self.measureBlock {
+                testTry {
+                    let results: [NSManagedObject] = try self.manyCategories.toObjects(self.context)
+                    XCTAssert(results.count == self.manyCategories.count, "Unboxed Companies have to be the same amount of entities")
+                }
+            }
+        }
+    }
+    
+    
+//    func testUniqueRemovingItemFromNestedCollection() {
+//        var s1 = self.company
+//        
+//        testTry {
+//            try s1.save(self.context)
+//        }
+//        
+//        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+//        XCTAssertEqual(before.first?.employees.count, 4)
+//        
+//        s1.employees.removeFirst()
+//        
+//        testTry {
+//            try s1.save(self.context)
+//        }
+//        
+//        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+//        XCTAssertEqual(after.first?.employees.count, 3)
+//    }
+//    
+//    func testUniqueRemovingAllItemsFromNestedCollection() {
+//        var s1 = self.company
+//        
+//        // save for the first time
+//        testTry {
+//            try s1.save(self.context)
+//        }
+//        
+//        // check the count of employees
+//        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+//        XCTAssertEqual(before.first?.employees.count, 4)
+//        
+//        // remove all employees from original struct
+//        s1.employees.removeAll()
+//        
+//        // save the changes
+//        testTry {
+//            try s1.save(self.context)
+//        }
+//        
+//        // check for resulting
+//        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
+//        XCTAssertEqual(after.first?.employees.count, 0)
+//    }
+    
+}

--- a/CoreValueMacTests/UniqueTests.swift
+++ b/CoreValueMacTests/UniqueTests.swift
@@ -27,6 +27,12 @@ struct Author : CVManagedUniqueStruct {
             <^> o <| "id"
             <^> o <| "name"
     }
+    
+    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
+    //        return try self.managedObject(context)
+    //            |> ("id", self.id)
+    //            |> ("name", self.name)
+    //    }
 }
 
 struct Article: CVManagedUniqueStruct {
@@ -39,7 +45,7 @@ struct Article: CVManagedUniqueStruct {
     var id: Int16
     var text: String
     var author: Author?
-
+    
     
     static func fromObject(o: NSManagedObject) throws -> Article {
         return try curry(self.init)
@@ -47,6 +53,13 @@ struct Article: CVManagedUniqueStruct {
             <^> o <| "text"
             <^> o <|? "author"
     }
+    
+    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
+    //        return try self.managedObject(context)
+    //                |> ("id", self.id)
+    //                |> ("text", self.text)
+    //                ?|> ("author", self.author)
+    //    }
 }
 
 struct Category: CVManagedUniqueStruct {
@@ -84,6 +97,14 @@ struct Category: CVManagedUniqueStruct {
             <^> o <| "label"
             <^> o <|| "articles"
     }
+    
+    //    func toObject(context: NSManagedObjectContext?) throws -> NSManagedObject {
+    //        return try self.managedObject(context)
+    //            |> ("id", self.id)
+    //            |> ("type", self.type)
+    //            |> ("label", self.label)
+    //            ||> ("articles", self.articles)
+    //    }
 }
 
 
@@ -129,7 +150,7 @@ class UniqueTests: XCTestCase {
     var manyCategories: [Category] = {
         var box: [Article] = []
         for c in 0..<25 {
-            box.append(Article(id: Int16(c), text: "text_\(c)", author: Author(id: "dfaw87", name: "Dostojevsky")))
+            box.append(Article(id: Int16(c), text: "text_\(c)", author: nil))
         }
         var companyBox: [Category] = []
         for c in 0..<50 {
@@ -139,7 +160,7 @@ class UniqueTests: XCTestCase {
     }()
     
     
-   
+    
     func testUniqueSavingTwoTimes() {
         let s1 = self.category
         
@@ -225,7 +246,7 @@ class UniqueTests: XCTestCase {
         let conflictedId = category.articles[0].id
         let conflictedArticle = Article( id: conflictedId, text: "conflicted_text", author: category.articles[0].author)
         category.articles.append(conflictedArticle)
-
+        
         testTry {
             try category.save(self.context)
         }
@@ -265,51 +286,4 @@ class UniqueTests: XCTestCase {
             }
         }
     }
-    
-    
-//    func testUniqueRemovingItemFromNestedCollection() {
-//        var s1 = self.company
-//        
-//        testTry {
-//            try s1.save(self.context)
-//        }
-//        
-//        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
-//        XCTAssertEqual(before.first?.employees.count, 4)
-//        
-//        s1.employees.removeFirst()
-//        
-//        testTry {
-//            try s1.save(self.context)
-//        }
-//        
-//        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
-//        XCTAssertEqual(after.first?.employees.count, 3)
-//    }
-//    
-//    func testUniqueRemovingAllItemsFromNestedCollection() {
-//        var s1 = self.company
-//        
-//        // save for the first time
-//        testTry {
-//            try s1.save(self.context)
-//        }
-//        
-//        // check the count of employees
-//        let before: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
-//        XCTAssertEqual(before.first?.employees.count, 4)
-//        
-//        // remove all employees from original struct
-//        s1.employees.removeAll()
-//        
-//        // save the changes
-//        testTry {
-//            try s1.save(self.context)
-//        }
-//        
-//        // check for resulting
-//        let after: [StoredCompany] = try! StoredCompany.query(self.context, predicate: nil)
-//        XCTAssertEqual(after.first?.employees.count, 0)
-//    }
-    
 }


### PR DESCRIPTION
This is slightly bigger pull request. The idea is to - instead of NSManagedObjectID connect the struct using unique identifier.  It is especially useful in connection with Argo for decoding JSON. If the struct with an existing id is in the CoreData it is pulled (using fetch request) and updated. Otherwise new object is created.

This has the advantage of getting rid of NSManagedObjectID and all the mutating functions that are sometimes causing weird behaviour. 

The disadvantage is obviously slower performance as every struct have to find its corresponding nsmanagedobject based on identifier predicate. Based on tests, the performance is roughly worse by 1/3 of the original time (0.181 to 0.267), so I think it is manageable. 

I am using this for some time already in my projects and I am pretty happy with it so far.
Let me know what you think