### PR TITLE
Updated Swift legacy version flag to NO for all targets

### DIFF
--- a/CoreValue.xcodeproj/project.pbxproj
+++ b/CoreValue.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 				TargetAttributes = {
 					4D5912571B4989FB0022506E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0810;
 					};
 					4D5912611B4989FB0022506E = {
 						CreatedOnToolsVersion = 7.0;
@@ -537,6 +538,7 @@
 				PRODUCT_NAME = CoreValue;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -556,6 +558,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.terhechte.CoreValue;
 				PRODUCT_NAME = CoreValue;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};
@@ -566,6 +569,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.terhechte.CoreValueTests;
 				PRODUCT_NAME = CoreValue;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -576,6 +580,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.terhechte.CoreValueTests;
 				PRODUCT_NAME = CoreValue;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};
@@ -596,7 +601,7 @@
 				PRODUCT_NAME = CoreValue;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -617,7 +622,7 @@
 				PRODUCT_NAME = CoreValue;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};
@@ -631,7 +636,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.terhechte.CoreValueMacTests;
 				PRODUCT_NAME = CoreValue;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -645,7 +650,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.terhechte.CoreValueMacTests;
 				PRODUCT_NAME = CoreValue;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Hi there,

Even though the source code is Swift 3 ready the Swift legacy project flag for all targets was unspecified, causing carthage builds to fail. 

I've updated all targets, ran all tests again and successfully managed to build the framework using carthage. All the required changes are included in this pull request.

Cheers,
Rog
